### PR TITLE
Restrict combinatorics to ~> 0.4

### DIFF
--- a/radiation.gemspec
+++ b/radiation.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "plusminus"
   spec.add_dependency "open-uri-cached"
-  spec.add_dependency "combinatorics"
+  spec.add_dependency "combinatorics", "~> 0.4"
   spec.add_dependency "linefit"
   spec.add_dependency "xml-simple"
   spec.add_dependency "thor"


### PR DESCRIPTION
I'm planning on working on combinatorics 1.0.0, which will break compatibility with the 0.x.y API. Restricting combinatorics to `~> 0.4` will restrict combinatorics to the 0.x.y version family.